### PR TITLE
[Yosegi-23] UnsafeOptimizeDumpLongColumnBinaryMaker has incorrect calculation of byte array length.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi-legacy</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <packaging>jar</packaging>
   <name>Yosegi legacy</name>
   <description>Package for backward compatibility.</description>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>
       <artifactId>yosegi</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpDoubleColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpDoubleColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.compressor.FindCompressor;
 import jp.co.yahoo.yosegi.compressor.ICompressor;
@@ -51,6 +52,7 @@ public class DumpDoubleColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpFloatColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/DumpFloatColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.compressor.FindCompressor;
 import jp.co.yahoo.yosegi.compressor.ICompressor;
@@ -51,6 +52,7 @@ public class DumpFloatColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDoubleColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDoubleColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.BufferDirectSequentialNumberCellIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeDoubleIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -238,6 +239,7 @@ public class OptimizeDoubleColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDumpLongColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDumpLongColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeLongIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.SequentialNumberCellIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -578,6 +579,7 @@ public class OptimizeDumpLongColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDumpStringColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeDumpStringColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeStringIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.SequentialStringCellIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -268,10 +269,11 @@ public class OptimizeDumpStringColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     if ( column.size() == 0 ) {
       return new UnsupportedColumnBinaryMaker()
-          .toBinary( commonConfig , currentConfigNode , column );
+          .toBinary( commonConfig , currentConfigNode , compressResultNode , column );
     }
 
     ColumnBinaryMakerConfig currentConfig = commonConfig;

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeFloatColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeFloatColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.BufferDirectSequentialNumberCellIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeFloatIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -238,6 +239,7 @@ public class OptimizeFloatColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeIndexDumpStringColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeIndexDumpStringColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeStringIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.SequentialStringCellIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -446,10 +447,11 @@ public class OptimizeIndexDumpStringColumnBinaryMaker implements IColumnBinaryMa
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     if ( column.size() == 0 ) {
       return new UnsupportedColumnBinaryMaker()
-          .toBinary( commonConfig , currentConfigNode , column );
+          .toBinary( commonConfig , currentConfigNode , compressResultNode , column );
     }
 
     ColumnBinaryMakerConfig currentConfig = commonConfig;

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeLongColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeLongColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.BufferDirectSequentialNumberCellIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeLongIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -563,6 +564,7 @@ public class OptimizeLongColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeStringColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/OptimizeStringColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.BufferDirectSequentialStringCellIndex;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeStringIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
@@ -386,10 +387,11 @@ public class OptimizeStringColumnBinaryMaker implements IColumnBinaryMaker {
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     if ( column.size() == 0 ) {
       return new UnsupportedColumnBinaryMaker()
-          .toBinary( commonConfig , currentConfigNode , column );
+          .toBinary( commonConfig , currentConfigNode , compressResultNode , column );
     }
 
     ColumnBinaryMakerConfig currentConfig = commonConfig;

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/RangeDumpDoubleColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/RangeDumpDoubleColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeDoubleIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.blockindex.DoubleRangeBlockIndex;
@@ -51,6 +52,7 @@ public class RangeDumpDoubleColumnBinaryMaker extends DumpDoubleColumnBinaryMake
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/main/java/jp/co/yahoo/yosegi/binary/maker/RangeDumpFloatColumnBinaryMaker.java
+++ b/src/main/java/jp/co/yahoo/yosegi/binary/maker/RangeDumpFloatColumnBinaryMaker.java
@@ -21,6 +21,7 @@ package jp.co.yahoo.yosegi.binary.maker;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.binary.maker.index.RangeFloatIndex;
 import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.blockindex.FloatRangeBlockIndex;
@@ -51,6 +52,7 @@ public class RangeDumpFloatColumnBinaryMaker extends DumpFloatColumnBinaryMaker 
   public ColumnBinary toBinary(
       final ColumnBinaryMakerConfig commonConfig ,
       final ColumnBinaryMakerCustomConfigNode currentConfigNode ,
+      final CompressResultNode compressResultNode ,
       final IColumn column ) throws IOException {
     ColumnBinaryMakerConfig currentConfig = commonConfig;
     if ( currentConfigNode != null ) {

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestDumpDoubleColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestDumpDoubleColumnBinaryMaker.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 
@@ -139,7 +140,7 @@ public class TestDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new DumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -167,7 +168,7 @@ public class TestDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new DumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 3 );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestDumpFloatColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestDumpFloatColumnBinaryMaker.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
@@ -140,7 +141,7 @@ public class TestDumpFloatColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new DumpFloatColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "FLOAT" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -168,7 +169,7 @@ public class TestDumpFloatColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new DumpFloatColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "FLOAT" );
     assertEquals( columnBinary.rowCount , 3 );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeDumpLongColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeDumpLongColumnBinaryMaker.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 
 import jp.co.yahoo.yosegi.message.objects.*;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
@@ -143,7 +144,7 @@ public class TestOptimizeDumpLongColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpLongColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "SHORT" );
     assertEquals( columnBinary.rowCount , 6 );
@@ -173,7 +174,7 @@ public class TestOptimizeDumpLongColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpLongColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "C" );
     assertEquals( columnBinary.rowCount , 6 );
@@ -203,7 +204,7 @@ public class TestOptimizeDumpLongColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpLongColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "INTEGER" );
     assertEquals( columnBinary.rowCount , 6 );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeDumpStringColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeDumpStringColumnBinaryMaker.java
@@ -37,6 +37,7 @@ import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 
@@ -144,7 +145,7 @@ public class TestOptimizeDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );
@@ -173,7 +174,7 @@ public class TestOptimizeDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 6 );
@@ -201,7 +202,7 @@ public class TestOptimizeDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
   }
 
@@ -215,7 +216,7 @@ public class TestOptimizeDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -239,7 +240,7 @@ public class TestOptimizeDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeIndexDumpStringColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeIndexDumpStringColumnBinaryMaker.java
@@ -37,6 +37,7 @@ import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 
@@ -144,7 +145,7 @@ public class TestOptimizeIndexDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeIndexDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );
@@ -173,7 +174,7 @@ public class TestOptimizeIndexDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeIndexDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 6 );
@@ -201,7 +202,7 @@ public class TestOptimizeIndexDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeIndexDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
   }
 
@@ -215,7 +216,7 @@ public class TestOptimizeIndexDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeIndexDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -239,7 +240,7 @@ public class TestOptimizeIndexDumpStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeIndexDumpStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeLongColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeLongColumnBinaryMaker.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 
 import jp.co.yahoo.yosegi.message.objects.ShortObj;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
@@ -56,7 +57,7 @@ public class TestOptimizeLongColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeLongColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode(), column );
 
     assertEquals( columnBinary.columnName , "SHORT" );
     assertEquals( columnBinary.rowCount , 2 );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeStringColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestOptimizeStringColumnBinaryMaker.java
@@ -37,6 +37,7 @@ import jp.co.yahoo.yosegi.blockindex.BlockIndexNode;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 
@@ -144,7 +145,7 @@ public class TestOptimizeStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );
@@ -173,7 +174,7 @@ public class TestOptimizeStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 6 );
@@ -201,7 +202,7 @@ public class TestOptimizeStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
   }
 
@@ -215,7 +216,7 @@ public class TestOptimizeStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "STRING" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -240,7 +241,7 @@ public class TestOptimizeStringColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new OptimizeStringColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
     maker.setBlockIndexNode( new BlockIndexNode() , columnBinary , 0 );
 
     assertEquals( columnBinary.columnName , "STRING" );

--- a/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestRangeDumpDoubleColumnBinaryMaker.java
+++ b/src/test/java/jp/co/yahoo/yosegi/binary/maker/TestRangeDumpDoubleColumnBinaryMaker.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.binary.ColumnBinary;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
 import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
 import jp.co.yahoo.yosegi.inmemory.IMemoryAllocator;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
 
@@ -139,7 +140,7 @@ public class TestRangeDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new RangeDumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 2 );
@@ -167,7 +168,7 @@ public class TestRangeDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new RangeDumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 3 );
@@ -196,7 +197,7 @@ public class TestRangeDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new RangeDumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 3 );
@@ -222,7 +223,7 @@ public class TestRangeDumpDoubleColumnBinaryMaker {
     ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode( "root" , defaultConfig );
 
     IColumnBinaryMaker maker = new RangeDumpDoubleColumnBinaryMaker();
-    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , column );
+    ColumnBinary columnBinary = maker.toBinary( defaultConfig , null , new CompressResultNode() , column );
 
     assertEquals( columnBinary.columnName , "DOUBLE" );
     assertEquals( columnBinary.rowCount , 2 );


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
The upgrade is necessary to fix the following bugs.
https://yosegi.atlassian.net/browse/YOSEGI-23

### How did you do the test? (Not required for updating documents)
